### PR TITLE
feat(deps): upgrade `grommet-icons` 4.7.0 -> 4.8.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 615 total icons
+> 619 total icons
 
 ## Icons
 
@@ -151,6 +151,7 @@
 - Directions
 - DisabledOutline
 - Disc
+- DislikeFill
 - Dislike
 - Docker
 - DocumentCloud
@@ -242,6 +243,7 @@
 - FormLock
 - FormNextLink
 - FormNext
+- FormPin
 - FormPreviousLink
 - FormPrevious
 - FormRefresh
@@ -318,6 +320,7 @@
 - Launch
 - Layer
 - License
+- LikeFill
 - Like
 - LineChart
 - LinkBottom
@@ -488,6 +491,7 @@
 - StackOverflow
 - Stakeholder
 - StarHalf
+- StarOutline
 - Star
 - StatusCriticalSmall
 - StatusCritical
@@ -545,7 +549,7 @@
 - ThreeDEffects
 - ThreeD
 - Ticket
-- Tictok
+- Tiktok
 - Time
 - Tip
 - Toast

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "gh-pages": "^4.0.0",
-    "grommet-icons": "4.7.0",
+    "grommet-icons": "4.8.0",
     "rollup": "^2.79.0",
     "svelte": "^3.49.0",
     "svelte-check": "^2.9.0",

--- a/test/SvelteGrommetIcons.test.svelte
+++ b/test/SvelteGrommetIcons.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Analytics, Camera, DocumentImage } from "../lib";
+  import { Analytics, Camera, DocumentImage, FormPin } from "../lib";
   import Ad from "../lib/Ad.svelte";
 </script>
 
@@ -7,3 +7,4 @@
 <Camera />
 <DocumentImage />
 <Ad width="30" />
+<FormPin />

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,10 +487,10 @@ graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-grommet-icons@4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.7.0.tgz#1d537b2bdc507be07d5643309d433bbe1464c5b6"
-  integrity sha512-ptw8x86Age/Yz6SplCLtJ8q1z/4ZLktMruCOnE6oTgc7hcIV/8ieOucTrLbu+PDi7rKxoP321O3OG3Zo/3qXjw==
+grommet-icons@4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.8.0.tgz#3c9922b3662d0b9e22913ecbaa7b1101031b554b"
+  integrity sha512-8cS1zVib88SIyLfsWFFazMzYz/8k5MvXZqopUjN/Bnl8HvQBUe0Z87F+JXRb1AMMYkuqXQW9Pg6XfBB3Ro9VdQ==
   dependencies:
     grommet-styles "^0.2.0"
 


### PR DESCRIPTION
- upgrade `grommet-icons` to [v4.8.0](https://github.com/grommet/grommet-icons/releases/tag/v4.8.0) (net +4 icons)