### PR TITLE
feat(deps): upgrade `grommet-icons` 4.8.0 -> 4.10.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 619 total icons
+> 620 total icons
 
 ## Icons
 
@@ -57,6 +57,7 @@
 - Braille
 - Briefcase
 - Brush
+- Bucket
 - Bug
 - Bundle
 - Bus

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "gh-pages": "^5.0.0",
-    "grommet-icons": "4.8.0",
+    "grommet-icons": "4.10.0",
     "rollup": "^2.79.0",
     "svelte": "^3.55.1",
     "svelte-check": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -493,10 +493,10 @@ graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-grommet-icons@4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.8.0.tgz#3c9922b3662d0b9e22913ecbaa7b1101031b554b"
-  integrity sha512-8cS1zVib88SIyLfsWFFazMzYz/8k5MvXZqopUjN/Bnl8HvQBUe0Z87F+JXRb1AMMYkuqXQW9Pg6XfBB3Ro9VdQ==
+grommet-icons@4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.10.0.tgz#a56bc083f7d52502a12871c031a6746c61164cce"
+  integrity sha512-f3Re6jFRh93n2Cn2hyrJUANG7wOsv3wlEuyW/A1kIYzamDWnNfoZLgDQZXbAmMUMb1NdN7OU/0JrINxTCUOAEA==
   dependencies:
     grommet-styles "^0.2.0"
 


### PR DESCRIPTION
- upgrade `grommet-icons` to v4.10.0 (net +1 icon)